### PR TITLE
自動更新機能を実装   自分以外のユーザーが送信したメッセージも自動で追加表示

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -19,7 +19,7 @@ $(function(){
   function buildHTML(message){
     if (message.image) {  
       var html = `
-      <div class="message">
+      <div class="message" data-message-id="${message.id}">
         <div class="message__info">
           <div class="message__info__sender">
             ${message.user_name}
@@ -37,7 +37,7 @@ $(function(){
       </div>`
     } else {
       var html =
-          `<div class="message" data-message-id=${message.id}>
+          `<div class="message" data-message-id="${message.id}">
             <div class="message__info">
               <div class="message__info__sender">
                 ${message.user_name}
@@ -77,4 +77,53 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     });
   });
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    // 現在表示しているメッセージは<div class="message">達である。これらの内最後の要素のdata-message-id値を取得する。これが現在表示しているメッセージ中の最新id。
+    //以下は確認用のコンソール出力。
+    
+    //console.log(last_message_id);
+    //console.log($('.message:last').html());
+    //console.log($('.message:last').find(".message__info__date").text());
+    
+    //ajax通信開始
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      //特にurlは、「なにも指定しない」とこのajax通信をよびだした元のURLになります。
+      //TODO:通常このmessage.jsを呼ぶ元は「group/そのgroupのid値/messages」です。
+      //ならば、jsonのurlに"api/messages"と設定しておくと、このajaxリクエスト先は「group/そのgroupのid値/api/messages」にできるか検証しましょう。
+      //→無事「Started GET "/groups/6/api/messages」となっていることを確認し、api/messages#indexアクションの起動を確認しました。
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める。
+      data: {id: last_message_id}
+      //上のdataオプションのおかげで、「group/:group_id/api/messages」の飛び先＝「api/messages#index」でparamsをみれば、TODO:params[id:]としたら、この画面内で現在表示の最新のメッセージid値がでるはず。
+      //→params[id:]確認しました。大丈夫です。
+    })
+    .done(function(messages) {
+      //デバッグ用コンソール表示
+      console.log('success');
+      //追加するHTMLの入れ物を作る
+      var insertHTML = '';
+      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+      $.each(messages, function(i, message) {
+        console.log(last_message_id);
+        console.log(message);
+        //上は正しく表示される内容を確認するためのデバッグ用コンソール出力です。
+        insertHTML += buildHTML(message)
+      });
+      //メッセージが入ったHTMLに、入れ物ごと追加
+      $('.message-list').append(insertHTML);
+    })
+    .fail(function() {
+      alert('error');
+    });
+    }
+    //自己流デバッグ 「group/そのgroupのid値/messages」のURLを起動してwindow.onload=画像やDOMなど全部読み込みが終わったら、reloadMessages変数に入ってる関数を起動します。
+    //参考ページは https://rcmdnk.com/blog/2015/07/11/computer-javascript-jquery/
+    //でもなんの意味もなかった...。結局自力でリロードしないといけなくなり、リロードしたらDBから最新の状況を下ろすからいみがなかった...。
+    //window.onload=reloadMessages;
+  setInterval(reloadMessages, 7000);
 }); 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -105,17 +105,20 @@ $(function(){
     .done(function(messages) {
       //デバッグ用コンソール表示
       console.log('success');
-      //追加するHTMLの入れ物を作る
-      var insertHTML = '';
-      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
-      $.each(messages, function(i, message) {
-        console.log(last_message_id);
-        console.log(message);
-        //上は正しく表示される内容を確認するためのデバッグ用コンソール出力です。
-        insertHTML += buildHTML(message)
-      });
-      //メッセージが入ったHTMLに、入れ物ごと追加
-      $('.message-list').append(insertHTML);
+      if (messages.length !== 0){
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          console.log(last_message_id);
+          console.log(message);
+          //上は正しく表示される内容を確認するためのデバッグ用コンソール出力です。
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.message-list').append(insertHTML);
+        $('.message-list').animate({ scrollTop: $('.message-list')[0].scrollHeight});
+      }
     })
     .fail(function() {
       alert('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,10 +1,12 @@
 $(function(){
+  //一桁だけの数字を受け取ったら「0」な文字列を頭に付けてかえすメソッド
   function forceDoubleNumber(str){
     if (str.length==1){
       str='0'+str;
     }
     return str;
   }
+  //日付を正しい形式に変換して文字列として返すメソッド
   function getCreatedAtFixed(str){
     var fulldate=new Date(str);
     var year=(fulldate.getFullYear().toString()+'年');
@@ -15,7 +17,7 @@ $(function(){
     var return_str=year+month+day+' '+hour+minuite;
     return return_str;
   }
-  
+  //新着メッセージを動的に画面に出力するhtml要素を文字列として返すメソッド
   function buildHTML(message){
     if (message.image) {  
       var html = `
@@ -55,6 +57,7 @@ $(function(){
     }
     return html
   }
+  //イベント 新規メッセージ入力フォームのSendボタンを押した時(ajaxリクエスト実施)
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -77,45 +80,29 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     });
   });
+  //画面内表示のメッセージが最新のものではないなら、動的に表示する(←という役割を持つ無名関数を持つ変数)(ajaxリクエスト実施)
   var reloadMessages = function() {
     var last_message_id = $('.message:last').data("message-id");
-    // 現在表示しているメッセージは<div class="message">達である。これらの内最後の要素のdata-message-id値を取得する。これが現在表示しているメッセージ中の最新id。
-    //以下は確認用のコンソール出力。
-    
-    //console.log(last_message_id);
-    //console.log($('.message:last').html());
-    //console.log($('.message:last').find(".message__info__date").text());
-    
     //ajax通信開始
     $.ajax({
       //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
       url: "api/messages",
       //ルーティングで設定した通りhttpメソッドをgetに指定
-      //特にurlは、「なにも指定しない」とこのajax通信をよびだした元のURLになります。
-      //TODO:通常このmessage.jsを呼ぶ元は「group/そのgroupのid値/messages」です。
-      //ならば、jsonのurlに"api/messages"と設定しておくと、このajaxリクエスト先は「group/そのgroupのid値/api/messages」にできるか検証しましょう。
-      //→無事「Started GET "/groups/6/api/messages」となっていることを確認し、api/messages#indexアクションの起動を確認しました。
       type: 'get',
       dataType: 'json',
       //dataオプションでリクエストに値を含める。
       data: {id: last_message_id}
-      //上のdataオプションのおかげで、「group/:group_id/api/messages」の飛び先＝「api/messages#index」でparamsをみれば、TODO:params[id:]としたら、この画面内で現在表示の最新のメッセージid値がでるはず。
-      //→params[id:]確認しました。大丈夫です。
     })
     .done(function(messages) {
-      //デバッグ用コンソール表示
-      console.log('success');
+      //ajaxリクエストの結果のレスポンスである@messagesが1件以上あるなら、以下doneの中身を実行します。
       if (messages.length !== 0){
         //追加するHTMLの入れ物を作る
         var insertHTML = '';
         //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
         $.each(messages, function(i, message) {
-          console.log(last_message_id);
-          console.log(message);
-          //上は正しく表示される内容を確認するためのデバッグ用コンソール出力です。
           insertHTML += buildHTML(message)
         });
-        //メッセージが入ったHTMLに、入れ物ごと追加
+        //メッセージが入ったHTMLに、入れ物ごと追加 その後スクロール
         $('.message-list').append(insertHTML);
         $('.message-list').animate({ scrollTop: $('.message-list')[0].scrollHeight});
       }
@@ -123,15 +110,11 @@ $(function(){
     .fail(function() {
       alert('error');
     });
-    }
-    //自己流デバッグ 「group/そのgroupのid値/messages」のURLを起動してwindow.onload=画像やDOMなど全部読み込みが終わったら、reloadMessages変数に入ってる関数を起動します。
-    //参考ページは https://rcmdnk.com/blog/2015/07/11/computer-javascript-jquery/
-    //でもなんの意味もなかった...。結局自力でリロードしないといけなくなり、リロードしたらDBから最新の状況を下ろすからいみがなかった...。
-    //window.onload=reloadMessages;
-    if (document.location.href.match(/\/groups\/\d+\/messages/)) {
-      setInterval(reloadMessages, 7000);
-      //自動更新メソッドの起動用のsetIntervalに条件をつける。
-      //document.location.href=現在アクセスしているURL が正規表現とマッチするなら、setIntervalで待ち受ける
-      //参考 https://www.sejuku.net/blog/26999
-    }
+  }
+  //メッセージの表示を自動更新を実行している箇所
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+    //自動更新メソッドを持つ変数reloadMessagesへのアクセス以下の条件とする。
+    //ブラウザで現在アクセスしているURL が正規表現「/groups/なにか数字/messages」とマッチするか。
+  }
 }); 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -128,5 +128,10 @@ $(function(){
     //参考ページは https://rcmdnk.com/blog/2015/07/11/computer-javascript-jquery/
     //でもなんの意味もなかった...。結局自力でリロードしないといけなくなり、リロードしたらDBから最新の状況を下ろすからいみがなかった...。
     //window.onload=reloadMessages;
-  setInterval(reloadMessages, 7000);
+    if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+      setInterval(reloadMessages, 7000);
+      //自動更新メソッドの起動用のsetIntervalに条件をつける。
+      //document.location.href=現在アクセスしているURL が正規表現とマッチするなら、setIntervalで待ち受ける
+      //参考 https://www.sejuku.net/blog/26999
+    }
 }); 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,15 @@
+class Api::MessagesController < ApplicationController
+  # このアクションはajaxで呼ばれるはずです。
+  def index
+    group = Group.find(params[:group_id])
+    # 現在表示している画面のグループidをparams=ajaxのjsonからとり、検索。
+    # ↑？ルーティングからとる？ajaxではなくて?(ルーティング設定と合わせてこのアクションへつなげるようにビューのリンクを変えるかも？)
+    last_message_id = params[:id].to_i
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    #whereの中はDBの検索の条件ですが、messagesテーブル内のid>lastmessage_idという条件にしたい。
+    # https://www.sejuku.net/blog/71189 を参考。
+    
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,35 +1,11 @@
 class Api::MessagesController < ApplicationController
-  # このアクションはajaxで呼ばれるはずです。
   def index
     group = Group.find(params[:group_id])
-    # 現在表示している画面のグループidをparams=ajaxのjsonからとり、検索。
-    # ↑？ルーティングからとる？ajaxではなくて?(ルーティング設定と合わせてこのアクションへつなげるようにビューのリンクを変えるかも？)
     last_message_id = params[:id].to_i
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
-    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
-    #whereの中はDBの検索の条件ですが、messagesテーブル内のid>lastmessage_idという条件にしたい。
-    # https://www.sejuku.net/blog/71189 を参考。
-    
     respond_to do |format|
        format.html
        format.json
     end
-    #jsonレスポンスを行います
-    #TODO:これがなくても表示がされた理由がわからない...。なぜ？
-    
-    puts "|||||||||||||||"
-    puts params
-    puts "last_message_id = #{last_message_id}"
-    # 上はajax通信が無事できているか確認用のparams表示
-    #--結論--
-    #無事、
-    #「url→group/groupのid値/messages」にアクセスしたら、messages.jsのデバッグ用windows.onloadが発火
-    #→messages.js内のajaxリクエストメソッドが起動。jsonリクエスト用のキーバリューで「url: "api/messages"」と「data: {id: last_message_id}」を設定
-    #   (last_message_id=$('.messages:last').data(message-id)として、あらかじめそのメッセージのDBのid=カスタムデータ属性値としてるのを取得。)
-    #→リクエスト先が「group/groupのid値/api/messages」になり、rails rouetsより,api/messages#indexが起動。(=このファイルのこのアクション)
-    #→上のputs paramsで、コンソールに{id : 現在「url→group/groupのid値/messages」ページで表示しているメッセージ中の最新メッセージid}
-    #が表示されることを確認しました。
-    
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -11,5 +11,25 @@ class Api::MessagesController < ApplicationController
     #whereの中はDBの検索の条件ですが、messagesテーブル内のid>lastmessage_idという条件にしたい。
     # https://www.sejuku.net/blog/71189 を参考。
     
+    respond_to do |format|
+       format.html
+       format.json
+    end
+    #jsonレスポンスを行います
+    #TODO:これがなくても表示がされた理由がわからない...。なぜ？
+    
+    puts "|||||||||||||||"
+    puts params
+    puts "last_message_id = #{last_message_id}"
+    # 上はajax通信が無事できているか確認用のparams表示
+    #--結論--
+    #無事、
+    #「url→group/groupのid値/messages」にアクセスしたら、messages.jsのデバッグ用windows.onloadが発火
+    #→messages.js内のajaxリクエストメソッドが起動。jsonリクエスト用のキーバリューで「url: "api/messages"」と「data: {id: last_message_id}」を設定
+    #   (last_message_id=$('.messages:last').data(message-id)として、あらかじめそのメッセージのDBのid=カスタムデータ属性値としてるのを取得。)
+    #→リクエスト先が「group/groupのid値/api/messages」になり、rails rouetsより,api/messages#indexが起動。(=このファイルのこのアクション)
+    #→上のputs paramsで、コンソールに{id : 現在「url→group/groupのid値/messages」ページで表示しているメッセージ中の最新メッセージid}
+    #が表示されることを確認しました。
+    
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -4,7 +4,9 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image.url
-  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  #json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  #上記コメントアウトではただしく表示されないので、javascript側で正しく表示します。
+  json.created_at message.created_at
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,10 @@
+# api::messageコントローラのindexアクションがレスポンスするview(json)を定義します。
+# api::messageコントローラのindexアクションでは、新しいメッセージ(復数)を@messagesで持っています。
+#@messagesの件数分だけ、jsonを定義し、配列としてjsonを返します。
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,6 @@
-.message
+-# 下は<div class="message">タグにカスタムデータ属性を設定します。
+-# 出来上がるのは<div class="message" data-message-id="そのメッセージのmessagesテーブルのid値">
+.message{data: {message: {id: message.id}}}
   .message__info
     .message__info__sender
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,3 @@
--# 下は<div class="message">タグにカスタムデータ属性を設定します。
--# 出来上がるのは<div class="message" data-message-id="そのメッセージのmessagesテーブルのid値">
 .message{data: {message: {id: message.id}}}
   .message__info
     .message__info__sender

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,8 +1,5 @@
 json.content    @message.content
 json.image      @message.image.url
-#json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-#上記コメントアウトではただしく表示されないので、javascript側で正しく表示します。
 json.created_at @message.created_at
 json.user_name @message.user.name
-#idもデータとして渡す
 json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,5 @@ json.content @message.content
 json.user_name @message.user.name
 json.created_at @message.created_at
 json.image @message.image_url
+#idもデータとして渡す
+json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,6 +1,8 @@
-json.content @message.content
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
+#json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+#上記コメントアウトではただしく表示されないので、javascript側で正しく表示します。
 json.created_at @message.created_at
-json.image @message.image_url
+json.user_name @message.user.name
 #idもデータとして渡す
 json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,17 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update, :destroy,:index]
+  resources :users, only: [:edit, :update,:index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    #以下は、namespaceを設定したmessagesコントローラへのルーティング設定。groupsルーティングのネストになっています。
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+      #このapi::message#indexはjsonでレスポンスするようにdefaultsオプションを設定
+      #以上より「/groups/:id/api/messages」というURLなら、api::message#index
+    end
   end
 end
+#ルーティングを極める参考URL
+# https://railsguides.jp/routing.html
+# https://techracho.bpsinc.jp/baba/2014_03_03/15619

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,14 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update,:index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-    #以下は、namespaceを設定したmessagesコントローラへのルーティング設定。groupsルーティングのネストになっています。
     namespace :api do
       resources :messages, only: :index, defaults: { format: 'json' }
-      #このapi::message#indexはjsonでレスポンスするようにdefaultsオプションを設定
-      #以上より「/groups/:id/api/messages」というURLなら、api::message#index
     end
   end
 end
-#ルーティングを極める参考URL
-# https://railsguides.jp/routing.html
-# https://techracho.bpsinc.jp/baba/2014_03_03/15619


### PR DESCRIPTION
# what
グループ内のメッセージ一覧画面に、表示中のメッセージよりも最新のメッセージがあるなら動的に表示する機能を実装します。
# why
ユーザがメッセージを新規投稿したとき、そのメッセージと同じグループを表示中の他のユーザがこのメッセージをみるためにブラウザリロードしなければならない問題を解決します。
# how
javascriptを用い、グループ内のメッセージ一覧画面をブラウザ表示中、一定のタイミングで表示中のメッセージよりも最新のメッセージがあるなら表示するようajaxリクエスト・レスポンスにて実施しています。

# result
画面の様子は以下になります。
<a href="https://gyazo.com/89db1e828a7bbfbd5c8f1bd5edfd745c"><img src="https://i.gyazo.com/89db1e828a7bbfbd5c8f1bd5edfd745c.gif" alt="Image from Gyazo" width="1000"/></a>